### PR TITLE
clients: allow specification of custom CLI args for every client

### DIFF
--- a/lib/src/clients/blobssss.rs
+++ b/lib/src/clients/blobssss.rs
@@ -1,5 +1,5 @@
 use crate::clients::Client;
-use crate::clients::CommonArgs;
+use crate::clients::CommonParams;
 use crate::config::shadow::Process;
 use crate::node::{NodeInfo, SimulationContext};
 use crate::validators::Validator;
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 #[derive(Deserialize, Debug, Clone)]
 pub struct Blobssss {
     #[serde(flatten)]
-    pub common: CommonArgs,
+    pub common: CommonParams,
     pub private_key: String,
     pub min_per_slot: u8,
     pub max_per_slot: u8,
@@ -34,7 +34,7 @@ impl Client for Blobssss {
                 self.max_per_slot,
                 self.private_key,
                 ctx.el_http_endpoints().iter().join(","),
-                self.common.extra_args,
+                self.common.arguments(""),
             ),
             environment: HashMap::default(),
             expected_final_state: "running".into(),

--- a/lib/src/clients/blobssss.rs
+++ b/lib/src/clients/blobssss.rs
@@ -1,19 +1,21 @@
-use std::collections::HashMap;
 use crate::clients::Client;
+use crate::clients::CommonArgs;
 use crate::config::shadow::Process;
 use crate::node::{NodeInfo, SimulationContext};
 use crate::validators::Validator;
 use crate::Error;
 use itertools::Itertools;
 use serde::Deserialize;
+use std::collections::HashMap;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Blobssss {
-    executable: String,
-    private_key: String,
-    min_per_slot: u8,
-    max_per_slot: u8,
-    start_time: String,
+    #[serde(flatten)]
+    pub common: CommonArgs,
+    pub private_key: String,
+    pub min_per_slot: u8,
+    pub max_per_slot: u8,
+    pub start_time: String,
 }
 
 #[typetag::deserialize(name = "blobssss")]
@@ -25,13 +27,14 @@ impl Client for Blobssss {
         _validators: &[Validator],
     ) -> Result<Process, Error> {
         Ok(Process {
-            path: self.executable.clone().into(),
+            path: self.common.executable_or("blobssss"),
             args: format!(
-                "--min {} --max {} --key {} --rpcs {}",
+                "--min {} --max {} --key {} --rpcs {} {}",
                 self.min_per_slot,
                 self.max_per_slot,
                 self.private_key,
                 ctx.el_http_endpoints().iter().join(","),
+                self.common.extra_args,
             ),
             environment: HashMap::default(),
             expected_final_state: "running".into(),

--- a/lib/src/clients/geth.rs
+++ b/lib/src/clients/geth.rs
@@ -1,4 +1,4 @@
-use crate::clients::CommonArgs;
+use crate::clients::CommonParams;
 use crate::clients::ENGINE_API_PORT;
 use crate::clients::{Client, JSON_RPC_PORT};
 use crate::config::shadow::Process;
@@ -17,7 +17,7 @@ const PORT: &str = "21000";
 #[serde(default)]
 pub struct Geth {
     #[serde(flatten)]
-    pub common: CommonArgs,
+    pub common: CommonParams,
 }
 
 #[typetag::deserialize(name = "geth")]
@@ -63,13 +63,11 @@ impl Client for Geth {
                 --port {PORT} \
                 --bootnodes {} \
                 --nat extip:{} \
-                --ipcdisable \
-                --log.file {dir}/geth.log \
-                --syncmode full {}",
+                --log.file {dir}/geth.log {}",
                 ctx.jwt_path().to_str().ok_or(Error::NonUTF8Path)?,
                 ctx.el_bootnode_enodes().join(","),
                 node.ip(),
-                self.common.extra_args,
+                self.common.arguments("--syncmode full --ipcdisable"),
             ),
             environment: HashMap::new(),
             expected_final_state: "running".into(),

--- a/lib/src/clients/geth.rs
+++ b/lib/src/clients/geth.rs
@@ -1,10 +1,10 @@
+use crate::clients::CommonArgs;
 use crate::clients::ENGINE_API_PORT;
 use crate::clients::{Client, JSON_RPC_PORT};
 use crate::config::shadow::Process;
 use crate::node::{NodeInfo, SimulationContext};
 use crate::utils::log_and_wait;
 use crate::validators::Validator;
-use crate::CowStr;
 use crate::Error;
 use log::debug;
 use serde::Deserialize;
@@ -13,18 +13,11 @@ use std::process::Command;
 
 const PORT: &str = "21000";
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Default)]
 #[serde(default)]
 pub struct Geth {
-    pub executable: CowStr,
-}
-
-impl Default for Geth {
-    fn default() -> Self {
-        Self {
-            executable: "geth".into(),
-        }
-    }
+    #[serde(flatten)]
+    pub common: CommonArgs,
 }
 
 #[typetag::deserialize(name = "geth")]
@@ -41,9 +34,11 @@ impl Client for Geth {
         let dir = node.dir().join("geth");
         let dir = dir.to_str().ok_or(Error::NonUTF8Path)?;
 
+        let executable = self.common.executable_or("geth");
+
         debug!("Calling geth init");
         let status = log_and_wait(
-            Command::new(self.executable.as_ref())
+            Command::new(executable.as_ref())
                 .arg("init")
                 .arg("--datadir")
                 .arg(dir)
@@ -56,7 +51,7 @@ impl Client for Geth {
         ctx.add_el_http_endpoint(format!("http://{}:{JSON_RPC_PORT}", node.ip()));
 
         Ok(Process {
-            path: self.executable.clone(),
+            path: executable,
             args: format!(
                 "--datadir {dir} \
                 --authrpc.port {ENGINE_API_PORT} \
@@ -70,10 +65,11 @@ impl Client for Geth {
                 --nat extip:{} \
                 --ipcdisable \
                 --log.file {dir}/geth.log \
-                --syncmode full",
+                --syncmode full {}",
                 ctx.jwt_path().to_str().ok_or(Error::NonUTF8Path)?,
                 ctx.el_bootnode_enodes().join(","),
                 node.ip(),
+                self.common.extra_args,
             ),
             environment: HashMap::new(),
             expected_final_state: "running".into(),

--- a/lib/src/clients/geth_bootnode.rs
+++ b/lib/src/clients/geth_bootnode.rs
@@ -56,7 +56,7 @@ impl Client for GethBootnode {
             ),
             environment: HashMap::new(),
             expected_final_state: "running".into(),
-            start_time: "0s".into()
+            start_time: "0s".into(),
         })
     }
 }

--- a/lib/src/clients/geth_bootnode.rs
+++ b/lib/src/clients/geth_bootnode.rs
@@ -1,4 +1,4 @@
-use crate::clients::CommonArgs;
+use crate::clients::CommonParams;
 use std::collections::HashMap;
 use std::fs::{create_dir, File};
 use std::io::Write;
@@ -17,7 +17,7 @@ const DISC_PORT: u16 = 30305;
 #[serde(default)]
 pub struct GethBootnode {
     #[serde(flatten)]
-    pub common: CommonArgs,
+    pub common: CommonParams,
 }
 
 #[typetag::deserialize(name = "geth_bootnode")]
@@ -50,10 +50,9 @@ impl Client for GethBootnode {
             path: self.common.executable_or("bootnode"),
             args: format!(
                 "-nodekey \"{key_file}\" \
-                -verbosity 5 \
                 -addr :{DISC_PORT} \
                 -nat extip:{ip} {}",
-                self.common.extra_args,
+                self.common.arguments("-verbosity 5"),
             ),
             environment: HashMap::new(),
             expected_final_state: "running".into(),

--- a/lib/src/clients/geth_bootnode.rs
+++ b/lib/src/clients/geth_bootnode.rs
@@ -1,3 +1,4 @@
+use crate::clients::CommonArgs;
 use std::collections::HashMap;
 use std::fs::{create_dir, File};
 use std::io::Write;
@@ -8,23 +9,15 @@ use serde::Deserialize;
 use crate::clients::{Client, Validator};
 use crate::config::shadow::Process;
 use crate::node::{NodeInfo, SimulationContext};
-use crate::CowStr;
 use crate::Error;
 
 const DISC_PORT: u16 = 30305;
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Default)]
 #[serde(default)]
 pub struct GethBootnode {
-    pub executable: CowStr,
-}
-
-impl Default for GethBootnode {
-    fn default() -> Self {
-        Self {
-            executable: "bootnode".into(),
-        }
-    }
+    #[serde(flatten)]
+    pub common: CommonArgs,
 }
 
 #[typetag::deserialize(name = "geth_bootnode")]
@@ -54,16 +47,17 @@ impl Client for GethBootnode {
         ctx.add_el_bootnode_enode(format!("enode://{pub_key}@{ip}:0?discport={DISC_PORT}"));
 
         Ok(Process {
-            path: self.executable.clone(),
+            path: self.common.executable_or("bootnode"),
             args: format!(
                 "-nodekey \"{key_file}\" \
                 -verbosity 5 \
                 -addr :{DISC_PORT} \
-                -nat extip:{ip}"
+                -nat extip:{ip} {}",
+                self.common.extra_args,
             ),
             environment: HashMap::new(),
             expected_final_state: "running".into(),
-            start_time: "0s".into(),
+            start_time: "0s".into()
         })
     }
 }

--- a/lib/src/clients/lighthouse.rs
+++ b/lib/src/clients/lighthouse.rs
@@ -1,5 +1,5 @@
 use crate::clients::Client;
-use crate::clients::CommonArgs;
+use crate::clients::CommonParams;
 use crate::clients::{BEACON_API_PORT, CL_PROMETHEUS_PORT, ENGINE_API_PORT};
 use crate::config::shadow::Process;
 use crate::node::{NodeInfo, SimulationContext};
@@ -14,14 +14,14 @@ const PORT: &str = "31000";
 #[serde(default)]
 pub struct Lighthouse {
     #[serde(flatten)]
-    pub common: CommonArgs,
+    pub common: CommonParams,
     pub lower_target_peers: bool,
 }
 
 impl Default for Lighthouse {
     fn default() -> Self {
         Self {
-            common: CommonArgs::default(),
+            common: CommonParams::default(),
             lower_target_peers: true,
         }
     }
@@ -60,16 +60,13 @@ impl Client for Lighthouse {
                 --enr-tcp-port {PORT} \
                 --http \
                 --http-port {BEACON_API_PORT} \
-                --disable-quic \
-                --disable-upnp \
-                --disable-packet-filter \
                 --metrics-address 0.0.0.0 \
                 --metrics-port {CL_PROMETHEUS_PORT} \
                 --metrics {}",
             ctx.metadata_path().to_str().ok_or(Error::NonUTF8Path)?,
             ctx.jwt_path().to_str().ok_or(Error::NonUTF8Path)?,
             ctx.cl_bootnode_enrs().join(","),
-            self.common.extra_args,
+            self.common.arguments("--disable-quic --disable-upnp --disable-packet-filter"),
         );
         if self.lower_target_peers && ctx.num_cl_clients() <= 100 {
             args.push_str(&format!("--target-peers {}", ctx.num_cl_clients() - 1));

--- a/lib/src/clients/lighthouse.rs
+++ b/lib/src/clients/lighthouse.rs
@@ -66,7 +66,8 @@ impl Client for Lighthouse {
             ctx.metadata_path().to_str().ok_or(Error::NonUTF8Path)?,
             ctx.jwt_path().to_str().ok_or(Error::NonUTF8Path)?,
             ctx.cl_bootnode_enrs().join(","),
-            self.common.arguments("--disable-quic --disable-upnp --disable-packet-filter"),
+            self.common
+                .arguments("--disable-quic --disable-upnp --disable-packet-filter"),
         );
         if self.lower_target_peers && ctx.num_cl_clients() <= 100 {
             args.push_str(&format!("--target-peers {}", ctx.num_cl_clients() - 1));

--- a/lib/src/clients/lighthouse_bootnode.rs
+++ b/lib/src/clients/lighthouse_bootnode.rs
@@ -1,3 +1,4 @@
+use crate::clients::CommonArgs;
 use log::debug;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -16,14 +17,15 @@ const PORT: &str = "4011";
 #[derive(Deserialize, Debug, Clone)]
 #[serde(default)]
 pub struct LighthouseBootnode {
-    pub executable: CowStr,
+    #[serde(flatten)]
+    pub common: CommonArgs,
     pub lcli_executable: CowStr,
 }
 
 impl Default for LighthouseBootnode {
     fn default() -> Self {
         Self {
-            executable: "lighthouse".into(),
+            common: CommonArgs::default(),
             lcli_executable: "lcli".into(),
         }
     }
@@ -66,15 +68,16 @@ impl Client for LighthouseBootnode {
         ctx.add_cl_bootnode_enr(enr);
 
         Ok(Process {
-            path: self.executable.clone(),
+            path: self.common.executable_or("lighthouse"),
             args: format!(
                 "--testnet-dir \"{}\" \
                 boot_node \
                 --port {PORT} \
                 --disable-packet-filter \
-                --network-dir {}",
+                --network-dir {} {}",
                 ctx.metadata_path().to_str().ok_or(Error::NonUTF8Path)?,
                 dir.to_str().ok_or(Error::NonUTF8Path)?,
+                self.common.extra_args,
             ),
             environment: HashMap::new(),
             expected_final_state: "running".into(),

--- a/lib/src/clients/lighthouse_bootnode.rs
+++ b/lib/src/clients/lighthouse_bootnode.rs
@@ -1,4 +1,4 @@
-use crate::clients::CommonArgs;
+use crate::clients::CommonParams;
 use log::debug;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -18,14 +18,14 @@ const PORT: &str = "4011";
 #[serde(default)]
 pub struct LighthouseBootnode {
     #[serde(flatten)]
-    pub common: CommonArgs,
+    pub common: CommonParams,
     pub lcli_executable: CowStr,
 }
 
 impl Default for LighthouseBootnode {
     fn default() -> Self {
         Self {
-            common: CommonArgs::default(),
+            common: CommonParams::default(),
             lcli_executable: "lcli".into(),
         }
     }
@@ -73,11 +73,10 @@ impl Client for LighthouseBootnode {
                 "--testnet-dir \"{}\" \
                 boot_node \
                 --port {PORT} \
-                --disable-packet-filter \
                 --network-dir {} {}",
                 ctx.metadata_path().to_str().ok_or(Error::NonUTF8Path)?,
                 dir.to_str().ok_or(Error::NonUTF8Path)?,
-                self.common.extra_args,
+                self.common.arguments("--disable-packet-filter"),
             ),
             environment: HashMap::new(),
             expected_final_state: "running".into(),

--- a/lib/src/clients/lighthouse_vc.rs
+++ b/lib/src/clients/lighthouse_vc.rs
@@ -1,29 +1,21 @@
+use crate::clients::CommonArgs;
 use crate::clients::BEACON_API_PORT;
 use crate::clients::{Client, ValidatorDemand};
 use crate::config::shadow::Process;
 use crate::node::{NodeInfo, SimulationContext};
 use crate::validators::Validator;
-use crate::CowStr;
 use crate::Error;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs;
 use std::fs::create_dir;
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Default)]
 #[serde(default)]
 pub struct LighthouseValidatorClient {
-    pub executable: CowStr,
+    #[serde(flatten)]
+    pub common: CommonArgs,
     pub validators: Option<usize>,
-}
-
-impl Default for LighthouseValidatorClient {
-    fn default() -> Self {
-        Self {
-            executable: "lighthouse".into(),
-            validators: None,
-        }
-    }
 }
 
 #[typetag::deserialize(name = "lighthouse_vc")]
@@ -62,15 +54,16 @@ impl Client for LighthouseValidatorClient {
         }
 
         Ok(Process {
-            path: self.executable.clone(),
+            path: self.common.executable_or("lighthouse"),
             args: format!(
                 "--testnet-dir \"{}\" \
                 validator_client \
                 --datadir \"{dir_str}\" \
                 --beacon-nodes http://localhost:{BEACON_API_PORT} \
                 --suggested-fee-recipient 0xf97e180c050e5Ab072211Ad2C213Eb5AEE4DF134 \
-                --init-slashing-protection",
+                --init-slashing-protection {}",
                 ctx.metadata_path().to_str().ok_or(Error::NonUTF8Path)?,
+                self.common.extra_args,
             ),
             environment: HashMap::new(),
             expected_final_state: "running".into(),

--- a/lib/src/clients/lighthouse_vc.rs
+++ b/lib/src/clients/lighthouse_vc.rs
@@ -1,4 +1,4 @@
-use crate::clients::CommonArgs;
+use crate::clients::CommonParams;
 use crate::clients::BEACON_API_PORT;
 use crate::clients::{Client, ValidatorDemand};
 use crate::config::shadow::Process;
@@ -14,7 +14,7 @@ use std::fs::create_dir;
 #[serde(default)]
 pub struct LighthouseValidatorClient {
     #[serde(flatten)]
-    pub common: CommonArgs,
+    pub common: CommonParams,
     pub validators: Option<usize>,
 }
 
@@ -60,10 +60,11 @@ impl Client for LighthouseValidatorClient {
                 validator_client \
                 --datadir \"{dir_str}\" \
                 --beacon-nodes http://localhost:{BEACON_API_PORT} \
-                --suggested-fee-recipient 0xf97e180c050e5Ab072211Ad2C213Eb5AEE4DF134 \
                 --init-slashing-protection {}",
                 ctx.metadata_path().to_str().ok_or(Error::NonUTF8Path)?,
-                self.common.extra_args,
+                self.common.arguments(
+                    "--suggested-fee-recipient 0xf97e180c050e5Ab072211Ad2C213Eb5AEE4DF134"
+                ),
             ),
             environment: HashMap::new(),
             expected_final_state: "running".into(),

--- a/lib/src/clients/mod.rs
+++ b/lib/src/clients/mod.rs
@@ -52,19 +52,38 @@ pub trait Client: Debug {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, Default)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(default)]
-pub struct CommonArgs {
+pub struct CommonParams {
     pub executable: String,
     pub extra_args: String,
+    pub use_recommended_args: bool,
 }
 
-impl CommonArgs {
+impl Default for CommonParams {
+    fn default() -> Self {
+        CommonParams {
+            executable: String::new(),
+            extra_args: String::new(),
+            use_recommended_args: true,
+        }
+    }
+}
+
+impl CommonParams {
     pub fn executable_or(&self, default: &'static str) -> CowStr {
         if self.executable.is_empty() {
             default.into()
         } else {
             self.executable.clone().into()
+        }
+    }
+
+    pub fn arguments(&self, recommended: &'static str) -> String {
+        if self.use_recommended_args && !recommended.is_empty() {
+            format!("{} {}", recommended, self.extra_args)
+        } else {
+            self.extra_args.clone()
         }
     }
 }

--- a/lib/src/clients/mod.rs
+++ b/lib/src/clients/mod.rs
@@ -1,7 +1,9 @@
 use crate::config::shadow::Process;
 use crate::node::{NodeInfo, SimulationContext};
 use crate::validators::Validator;
+use crate::CowStr;
 use crate::Error;
+use serde::Deserialize;
 use std::fmt::Debug;
 
 const ENGINE_API_PORT: &str = "21001";
@@ -47,5 +49,22 @@ pub trait Client: Debug {
     }
     fn is_el_client(&self) -> bool {
         false
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+#[serde(default)]
+pub struct CommonArgs {
+    pub executable: String,
+    pub extra_args: String,
+}
+
+impl CommonArgs {
+    pub fn executable_or(&self, default: &'static str) -> CowStr {
+        if self.executable.is_empty() {
+            default.into()
+        } else {
+            self.executable.clone().into()
+        }
     }
 }

--- a/lib/src/clients/prometheus.rs
+++ b/lib/src/clients/prometheus.rs
@@ -1,5 +1,5 @@
 use crate::clients::Client;
-use crate::clients::CommonArgs;
+use crate::clients::CommonParams;
 use crate::config::shadow::Process;
 use crate::node::{NodeInfo, SimulationContext};
 use crate::validators::Validator;
@@ -13,7 +13,7 @@ use std::fs::File;
 #[serde(default)]
 pub struct Prometheus {
     #[serde(flatten)]
-    common: CommonArgs,
+    common: CommonParams,
 }
 
 #[derive(Serialize)]
@@ -70,7 +70,7 @@ impl Client for Prometheus {
                 "--storage.tsdb.path={} --config.file={} {}",
                 dir.to_str().ok_or(Error::NonUTF8Path)?,
                 config_file.to_str().ok_or(Error::NonUTF8Path)?,
-                self.common.extra_args,
+                self.common.arguments(""),
             ),
             environment: HashMap::default(),
             expected_final_state: "running".into(),

--- a/lib/src/clients/reth.rs
+++ b/lib/src/clients/reth.rs
@@ -1,4 +1,4 @@
-use crate::clients::CommonArgs;
+use crate::clients::CommonParams;
 use crate::clients::ENGINE_API_PORT;
 use crate::clients::{Client, JSON_RPC_PORT};
 use crate::config::shadow::Process;
@@ -14,7 +14,7 @@ const PORT: &str = "21000";
 #[serde(default)]
 pub struct Reth {
     #[serde(flatten)]
-    pub common: CommonArgs,
+    pub common: CommonParams,
 }
 
 #[typetag::deserialize(name = "reth")]
@@ -48,12 +48,11 @@ impl Client for Reth {
                 --port {PORT} \
                 --bootnodes {} \
                 --nat extip:{} \
-                --ipcdisable \
                 --log.file.directory {dir} {}",
                 ctx.jwt_path().to_str().ok_or(Error::NonUTF8Path)?,
                 ctx.el_bootnode_enodes().join(","),
                 node.ip(),
-                self.common.extra_args,
+                self.common.arguments("--ipcdisable"),
             ),
             environment: HashMap::new(),
             expected_final_state: "running".into(),

--- a/lib/src/clients/reth.rs
+++ b/lib/src/clients/reth.rs
@@ -1,27 +1,20 @@
+use crate::clients::CommonArgs;
 use crate::clients::ENGINE_API_PORT;
 use crate::clients::{Client, JSON_RPC_PORT};
 use crate::config::shadow::Process;
 use crate::node::{NodeInfo, SimulationContext};
 use crate::validators::Validator;
-use crate::CowStr;
 use crate::Error;
 use serde::Deserialize;
 use std::collections::HashMap;
 
 const PORT: &str = "21000";
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Default)]
 #[serde(default)]
 pub struct Reth {
-    pub executable: CowStr,
-}
-
-impl Default for Reth {
-    fn default() -> Self {
-        Self {
-            executable: "reth".into(),
-        }
-    }
+    #[serde(flatten)]
+    pub common: CommonArgs,
 }
 
 #[typetag::deserialize(name = "reth")]
@@ -41,7 +34,7 @@ impl Client for Reth {
         ctx.add_el_http_endpoint(format!("http://{}:{JSON_RPC_PORT}", node.ip()));
 
         Ok(Process {
-            path: self.executable.clone(),
+            path: self.common.executable_or("reth"),
             args: format!(
                 "node \
                 --chain {genesis_file} \
@@ -56,10 +49,11 @@ impl Client for Reth {
                 --bootnodes {} \
                 --nat extip:{} \
                 --ipcdisable \
-                --log.file.directory {dir}",
+                --log.file.directory {dir} {}",
                 ctx.jwt_path().to_str().ok_or(Error::NonUTF8Path)?,
                 ctx.el_bootnode_enodes().join(","),
                 node.ip(),
+                self.common.extra_args,
             ),
             environment: HashMap::new(),
             expected_final_state: "running".into(),

--- a/lib/src/config/ethshadow.rs
+++ b/lib/src/config/ethshadow.rs
@@ -86,11 +86,7 @@ impl SugaredNode {
     fn combinations(&self) -> usize {
         self.locations.len()
             * self.reliabilities.len()
-            * self
-                .clients
-                .values()
-                .map(OneOrMany::len)
-                .product::<usize>()
+            * self.clients.values().map(OneOrMany::len).product::<usize>()
     }
 
     fn count_per_combination(&self) -> Result<usize, Error> {


### PR DESCRIPTION
A common use-case might be custom CLI arguments. This was only possible for Lighthouse, and has been extended to all clients. Furthermore, all default arguments that are not strictly necessary for Ethshadow to function are now toggleable.

Documentation for this feature will follow soon.