### PR TITLE
config: better way to specify custom hosts

### DIFF
--- a/lib/src/config/shadow.rs
+++ b/lib/src/config/shadow.rs
@@ -129,7 +129,7 @@ pub struct HostsMut<'a> {
 }
 
 impl<'a> Iterator for HostsMut<'a> {
-    type Item = Result<UntypedHost<&'a mut Mapping>, Error>;
+    type Item = Result<&'a mut Mapping, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.hosts
@@ -138,15 +138,6 @@ impl<'a> Iterator for HostsMut<'a> {
             .map(|(_, host)| {
                 host.as_mapping_mut()
                     .ok_or_else(|| Error::ExpectedOtherType("host".to_string()))
-                    .map(UntypedHost)
             })
-    }
-}
-
-pub struct UntypedHost<T>(T);
-
-impl<'a> UntypedHost<&'a mut Mapping> {
-    pub fn network_node_id_mut(&mut self) -> Option<&mut Value> {
-        self.0.get_mut("network_node_id")
     }
 }

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -51,4 +51,8 @@ pub enum Error {
             validator client"
     )]
     MissingValidatorCount,
+    #[error(
+        "You must specify a reliability and location, and no network_node_id in your custom hosts"
+    )]
+    InvalidShadowHost,
 }


### PR DESCRIPTION
Users can add their own hosts (e.g. attackers) via Shadow's host config.

As `network_node_id`s are unpredictable and generated by Ethshadow, the user has to specify the location and reliability for the custom host instead of a `network_node_id`.

Previously, this was done like this (replacing `<location>` and `<reliablilty>` as desired):
```
network_node_id: <location>-<reliability>
```

Now, it is done like this, which is nicer:
```
location: <location>
reliability: <reliability>
```

An error message instructs the correct usage. Documentation on this will follow soon.